### PR TITLE
added fetch polyfill to work on older browsers...like safari (lol)

### DIFF
--- a/client/app/actions/Action_AdvanceLevel.js
+++ b/client/app/actions/Action_AdvanceLevel.js
@@ -10,7 +10,7 @@ function advanceLevel(currlevel) {
       },
       method: 'POST',
       body: JSON.stringify({level: currlevel+1}),
-      credentials: "include"
+      credentials: "same-origin"
     }).then(response => {
       //parse the response and then called the action creator via promise
         if(response.status === 401) {

--- a/client/app/actions/Action_DeleteGame.js
+++ b/client/app/actions/Action_DeleteGame.js
@@ -7,7 +7,7 @@ function deleteGame(gameTitle) {
         'Content-Type': 'application/json'
       },
       method: 'POST',
-      credentials: "include",
+      credentials: "same-origin",
       body: JSON.stringify({gameTitle: gameTitle}),
     })
     .then(response => {

--- a/client/app/actions/Action_GetLevelData.js
+++ b/client/app/actions/Action_GetLevelData.js
@@ -7,7 +7,7 @@ function getLevelData() {
   return function(dispatch) {
     fetch(`api/leveldata`, {
       method: 'get',
-      credentials: "include"
+      credentials: "same-origin"
     })
     .then(response => {
       //parse the response and then called the action creator via promise

--- a/client/app/actions/Action_GetUserGame.js
+++ b/client/app/actions/Action_GetUserGame.js
@@ -4,7 +4,7 @@ function getUserGame(gameid) {
   return function(dispatch) {
     fetch(`api/usergames?id=${gameid}`, {
       method: 'get',
-      credentials: "include"
+      credentials: "same-origin"
     })
     .then(response => {
       //parse the response and then called the action creator via promise

--- a/client/app/actions/Action_SaveGame.js
+++ b/client/app/actions/Action_SaveGame.js
@@ -7,7 +7,7 @@ function saveGame(gameCode, title) {
         'Content-Type': 'application/json'
       },
       method: 'POST',
-      credentials: "include",
+      credentials: "same-origin",
       body: JSON.stringify({gameCode: gameCode, title: title}),
     })
     .then(response => {

--- a/client/app/actions/Action_ShareGame.js
+++ b/client/app/actions/Action_ShareGame.js
@@ -11,7 +11,7 @@ function shareGame(gameID) {
         'Content-Type': 'application/json'
       },
       method: 'POST',
-      credentials: "include",
+      credentials: "same-origin",
       body: JSON.stringify({ id: gameID }),
     })
     .then(response => {

--- a/client/app/actions/Action_UpdateLevel.js
+++ b/client/app/actions/Action_UpdateLevel.js
@@ -13,7 +13,7 @@ function updateLevel(advanceBoolean, currlevel) {
         advance: advanceBoolean,
         currlevel: currlevel
       }),
-      credentials: "include"
+      credentials: "same-origin"
     }).then(response => {
       //parse the response and then called the action creator via promise
         if(response.status === 401) {

--- a/client/app/actions/Action_UpdatePoints.js
+++ b/client/app/actions/Action_UpdatePoints.js
@@ -10,7 +10,7 @@ function updatePoints(currlevel,difflevel){
 				currlevel: currlevel,
 				difflevel: difflevel,
 			}),
-			credentials: "include"
+			credentials: "same-origin"
 		}).catch(err => {
 			console.log(err);
 		});

--- a/client/app/actions/Action_UserData.js
+++ b/client/app/actions/Action_UserData.js
@@ -13,7 +13,7 @@ function getProfileData(text) {
   return function(dispatch) {
     fetch('/api/userdata', {
       method: 'get',
-      credentials: "include"
+      credentials: "same-origin"
     }).then(response => {
       console.log('initialized', response)
       //parse the response and then called the action creator via promise

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   context: path.join(__dirname, '../client/app'),
-  entry: './index.js',
+  entry: ['whatwg-fetch','./index.js'],
   output: {
     path: path.join(__dirname, '../client/public'),
     filename: 'bundle.js'

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -3,6 +3,7 @@ var path = require('path');
 var config = {
   context: path.join(__dirname, '../client/app'),
   entry: [
+    'whatwg-fetch',
     './index.js',
   ],
   output: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "jasmine": "^2.5.2",
     "jasmine-spec-reporter": "^2.7.0",
     "supertest": "^2.0.1",
-    "webpack-dev-server": "^1.16.2"
+    "webpack-dev-server": "^1.16.2",
+    "whatwg-fetch": "^2.0.1"
   },
   "dependencies": {
     "babel-core": "6.11.4",


### PR DESCRIPTION
also changes all fetch requests to use credentials: 'same-origin' instead of credentials: 'include'.  same origin only automatically shares cookies with same origin sites, whereas include sends them with all requests.  same-origin is safer.